### PR TITLE
Fix heading, improve package handling in docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,13 +1,5 @@
 using Documenter
 
-try
-    using OMOPCDMCohortCreator
-catch
-    using Pkg
-    Pkg.add(url="github.com/JuliaHealth/OMOPCDMCohortCreator.jl", rev="main")
-    using OMOPCDMCohortCreator
-end
-
 makedocs(;
     modules = [OMOPCDMCohortCreator],
     authors = "Jacob Zelko (aka TheCedarPrince) <jacobszelko@gmail.com> and contributors",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,12 @@
-using OMOPCDMCohortCreator
 using Documenter
+
+try
+    using OMOPCDMCohortCreator
+catch
+    using Pkg
+    Pkg.add(url="github.com/JuliaHealth/OMOPCDMCohortCreator.jl", rev="main")
+    using OMOPCDMCohortCreator
+end
 
 makedocs(;
     modules = [OMOPCDMCohortCreator],
@@ -10,7 +17,7 @@ makedocs(;
         prettyurls = get(ENV, "CI", "false") == "true",
         canonical = "https://JuliaHealth.github.io/OMOPCDMCohortCreator.jl",
         assets = String[],
-        edit_branch = "main",
+        edit_link = "main",
 	footer = "Created by [Jacob Zelko](https://jacobzelko.com) & [Georgia Tech Research Institute](https://www.gtri.gatech.edu). [License](https://github.com/JuliaHealth/OMOPCDMCohortCreator.jl/blob/main/LICENSE)"
     ),
     pages = [

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,4 +1,4 @@
-# OMOPCDMCohortCreator API
+# API
 
 This is a list of documentation associated with every single **exported** function from `OMOPCDMCohortCreator`.
 There are a few different sections with a brief explanation of what these sections are followed by relevant functions.


### PR DESCRIPTION
Closes #19 ; the issue was in a different API heading. 
Another possible way to do it is to give it a unique name and reference it by the name, like so:
```
# OMOPCDMCohortCreator API[@id API]

here we reference [API](@ref API)
```
but imo it'll be a bit more tedious and time consuming. Also, tidied up a warning and made a failsafe to ensure module import.

If @TheCedarPrince has suggestions to edit it or he doesn't want to take the risk, just let me know! It's my first time with Julia, so things might me not up to par xd.
