### PR TITLE
Simplify Age Calculations

### DIFF
--- a/src/filters.jl
+++ b/src/filters.jl
@@ -1,5 +1,5 @@
 """
-VisitFilterPersonIDs(visit_codes, conn; tab::SQLTable = visit_occurrence)
+VisitFilterPersonIDs(visit_codes, conn; tab = visit_occurrence)
 
 Given a list of visit concept IDs, `visit_codes` return from the database patients matching at least one of the provided visit codes from the Visit Occurrence table.
 
@@ -11,26 +11,51 @@ Given a list of visit concept IDs, `visit_codes` return from the database patien
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
+- `tab` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
 
 # Returns
 
 - `ids::Vector{Int64}` - the list of persons resulting from the filter
 """
-function VisitFilterPersonIDs(visit_codes, conn; tab::SQLTable = visit_occurrence)
-    ids =
-        From(tab) |>
-        Where(Fun.in(Get.visit_concept_id, visit_codes...)) |>
-        Group(Get.person_id) |>
-        q -> render(q, dialect = dialect) |>
-        x -> DBInterface.execute(conn, String(x)) |> DataFrame
+function VisitFilterPersonIDs(visit_codes, conn; tab = visit_occurrence)
+    df = DBInterface.execute(conn, VisitFilterPersonIDs(visit_codes; tab = tab)) |> DataFrame
 
-    return convert(Vector{Int}, ids.person_id)
+    return df
 
 end
 
 """
-ConditionFilterPersonIDs(condition_codes, conn; tab::SQLTable = condition_occurrence)
+VisitFilterPersonIDs(visit_codes, conn; tab = visit_occurrence)
+
+TODO: Add documentation for dispatch
+
+# Arguments:
+
+- `visit_codes` - a vector of `visit_concept_id`'s; must be a subtype of `Integer`
+
+`conn` - database connection using DBInterface
+
+# Keyword Arguments:
+
+- `tab` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
+
+# Returns
+
+- `ids::Vector{Int64}` - the list of persons resulting from the filter
+"""
+function VisitFilterPersonIDs(visit_codes; tab = visit_occurrence)
+    sql =
+        From(tab) |>
+        Where(Fun.in(Get.visit_concept_id, visit_codes...)) |>
+        Group(Get.person_id) |>
+        q -> render(q, dialect = dialect) 
+
+        return String(sql)
+
+end
+
+"""
+ConditionFilterPersonIDs(condition_codes, conn; tab = condition_occurrence)
 
 Given a list of condition concept IDs, `condition_codes`, return from the database individuals having at least one entry in the Condition Occurrence table matching at least one of the provided condition types.
 
@@ -42,7 +67,7 @@ Given a list of condition concept IDs, `condition_codes`, return from the databa
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
+- `tab` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
 
 # Returns
 
@@ -52,19 +77,47 @@ function ConditionFilterPersonIDs(
     condition_codes, conn;
     tab = condition_occurrence,
 )
-    ids =
-        From(tab) |>
-        Where(Fun.in(Get.condition_concept_id, condition_codes...)) |>
-        Group(Get.person_id) |>
-        q -> render(q, dialect = dialect) |>
-        x -> DBInterface.execute(conn, String(x)) |> DataFrame
+    df = DBInterface.execute(conn, ConditionFilterPersonIDs(condition_codes; tab = tab)) |> DataFrame
 
-    return convert(Vector{Int}, ids.person_id)
+    return df 
 
 end
 
 """
-RaceFilterPersonIDs(race_codes, conn; tab::SQLTable = person)
+ConditionFilterPersonIDs(condition_codes, conn; tab = condition_occurrence)
+
+TODO: Add docstring for dispatch when ready
+
+# Arguments:
+
+- `condition_codes` - a vector of `condition_concept_id`'s; must be a subtype of `Integer`
+
+`conn` - database connection using DBInterface
+
+# Keyword Arguments:
+
+- `tab` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
+
+# Returns
+
+- `ids::Vector{Int64}` - the list of persons resulting from the filter
+"""
+function ConditionFilterPersonIDs(
+    condition_codes;
+    tab = condition_occurrence,
+)
+    sql =
+        From(tab) |>
+        Where(Fun.in(Get.condition_concept_id, condition_codes...)) |>
+        Group(Get.person_id) |>
+        q -> render(q, dialect = dialect)
+
+        return String(sql)
+
+end
+
+"""
+RaceFilterPersonIDs(race_codes, conn; tab = person)
 
 Given a list of condition concept IDs, `race_codes`, return from the database individuals having at least one entry in the Person table matching at least one of the provided race types.
 
@@ -76,26 +129,51 @@ Given a list of condition concept IDs, `race_codes`, return from the database in
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
 - `ids::Vector{Int64}` - the list of persons resulting from the filter
 """
 function RaceFilterPersonIDs(race_codes, conn; tab = person)
-    ids =
-        From(tab) |>
-        Where(Fun.in(Get.race_concept_id, race_codes...)) |>
-        Group(Get.person_id) |>
-        q -> render(q, dialect = dialect) |>
-        x -> DBInterface.execute(conn, String(x)) |> DataFrame
+    df = DBInterface.execute(conn, RaceFilterPersonIDs(race_codes; tab = tab)) |> DataFrame
 
-    return convert(Vector{Int}, ids.person_id)
+    return df
 
 end
 
 """
-GenderFilterPersonIDs(gender_codes, conn; tab::SQLTable = visit_occurrence)
+RaceFilterPersonIDs(race_codes, conn; tab = person)
+
+TODO: Add dispatch docstring when ready
+
+# Arguments:
+
+- `race_codes` - a vector of `race_concept_id`'s; must be a subtype of `Integer`
+
+`conn` - database connection using DBInterface
+
+# Keyword Arguments:
+
+- `tab` - the `SQLTable` representing the Person table; default `person`
+
+# Returns
+
+- `ids::Vector{Int64}` - the list of persons resulting from the filter
+"""
+function RaceFilterPersonIDs(race_codes; tab = person)
+    sql =
+        From(tab) |>
+        Where(Fun.in(Get.race_concept_id, race_codes...)) |>
+        Group(Get.person_id) |>
+        q -> render(q, dialect = dialect)
+
+    return String(sql)
+
+end
+
+"""
+GenderFilterPersonIDs(gender_codes, conn; tab = visit_occurrence)
 
 Given a list of visit concept IDs, `gender_codes` return from the database individuals having at least one entry in the Person table matching at least one of the provided gender types.
 
@@ -107,26 +185,51 @@ Given a list of visit concept IDs, `gender_codes` return from the database indiv
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
 - `ids::Vector{Int64}` - the list of persons resulting from the filter
 """
 function GenderFilterPersonIDs(gender_codes, conn; tab = person)
-    ids =
-        From(tab) |>
-        Where(Fun.in(Get.gender_concept_id, gender_codes...)) |>
-        Group(Get.person_id) |>
-        q -> render(q, dialect = dialect) |>
-        x -> DBInterface.execute(conn, String(x)) |> DataFrame
+    df = DBInterface.execute(conn, GenderFilterPersonIDs(gender_codes; tab = tab)) |> DataFrame
 
-    return convert(Vector{Int}, ids.person_id)
+    return df
 
 end
 
 """
-StateFilterPersonIDs(states, conn; tab::SQLTable = location, join_tab::SQLTable = person)
+GenderFilterPersonIDs(gender_codes, conn; tab = visit_occurrence)
+
+TODO: Add dispatch docstring when ready
+
+# Arguments:
+
+- `visit_codes` - a vector of `gender_concept_id`'s; must be a subtype of `Integer`
+
+`conn` - database connection using DBInterface
+
+# Keyword Arguments:
+
+- `tab` - the `SQLTable` representing the Person table; default `person`
+
+# Returns
+
+- `ids::Vector{Int64}` - the list of persons resulting from the filter
+"""
+function GenderFilterPersonIDs(gender_codes; tab = person)
+    sql =
+        From(tab) |>
+        Where(Fun.in(Get.gender_concept_id, gender_codes...)) |>
+        Group(Get.person_id) |>
+        q -> render(q, dialect = dialect)
+
+    return String(sql)
+
+end
+
+"""
+StateFilterPersonIDs(states, conn; tab = location, join_tab = person)
 
 Given a list of states, `states`, return from the database individuals found in the provided state list.
 
@@ -138,25 +241,50 @@ Given a list of states, `states`, return from the database individuals found in 
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Location table; default `location`
-- `join_tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Location table; default `location`
+- `join_tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
 - `ids::Vector{Int64}` - the list of persons resulting from the filter
 """
-function StateFilterPersonIDs(states, conn; tab::SQLTable = location, join_tab::SQLTable = person)
-    ids =
+function StateFilterPersonIDs(states, conn; tab = location, join_tab = person)
+    df = DBInterface.execute(conn, StateFilterPersonIDs(states; tab = tab, join_tab = join_tab)) |> DataFrame
+
+    return df
+
+end
+
+"""
+StateFilterPersonIDs(states, conn; tab = location, join_tab = person)
+
+Given a list of states, `states`, return from the database individuals found in the provided state list.
+
+# Arguments:
+
+- `states` - a vector of state abbreviations; must be a subtype of `AbstractString`
+
+`conn` - database connection using DBInterface
+
+# Keyword Arguments:
+
+- `tab` - the `SQLTable` representing the Location table; default `location`
+- `join_tab` - the `SQLTable` representing the Person table; default `person`
+
+# Returns
+
+- `ids::Vector{Int64}` - the list of persons resulting from the filter
+"""
+function StateFilterPersonIDs(states; tab = location, join_tab = person)
+    sql =
         From(tab) |>
         Select(Get.location_id, Get.state) |>
         Where(Fun.in(Get.state, uppercase.(states)...)) |>
         Join(:join => join_tab, Get.location_id .== Get.join.location_id) |>
         Select(Get.join.person_id) |>
-        q -> render(q, dialect = dialect) |>
-        x -> DBInterface.execute(conn, String(x)) |> DataFrame
+        q -> render(q, dialect = dialect)
 
-    return convert(Vector{Int}, ids.person_id)
+    return String(sql)
 
 end
-
 export VisitFilterPersonIDs, ConditionFilterPersonIDs, RaceFilterPersonIDs, GenderFilterPersonIDs, StateFilterPersonIDs

--- a/src/getters.jl
+++ b/src/getters.jl
@@ -1,5 +1,5 @@
 """
-GetDatabasePersonIDs(conn; tab::SQLTable = person)
+GetDatabasePersonIDs(conn; tab = person)
 
 Get all unique `person_id`'s from a database.
 
@@ -9,7 +9,7 @@ Get all unique `person_id`'s from a database.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -23,13 +23,63 @@ function GetDatabasePersonIDs(conn; tab=person)
 end
 
 """
-GetDatabasePersonIDs(; tab::SQLTable = person)
+GetDatabaseYearRange(conn; tab = observation_period)
+
+Get the years for which data is available from a database.
+
+# Arguments:
+
+- `conn` - database connection using DBInterface
+
+# Keyword Arguments:
+
+- `tab` - the `SQLTable` representing the Observation Period table; default `observation_period`
+
+# Returns
+
+- `year_range::NamedTuple{(:first_year, :last_year), Tuple{Int64, Int64}}` - a NamedTuple where `first_year` is the first year data from the database was available and `last_year` where the last year data from the database was available
+"""
+function GetDatabaseYearRange(conn; tab=observation_period)
+    years = DBInterface.execute(conn, String(GetDatabaseYearRange(tab=tab))) |> DataFrame 
+
+    return (first_year = first(years.first_year), last_year = first(years.last_year))
+
+end
+
+"""
+GetDatabaseYearRange(; tab = observation_period)
+
+TODO: Add docstring for dispatch
+
+# Arguments:
+
+# Keyword Arguments:
+
+- `tab` - the `SQLTable` representing the Observation Period table; default `observation_period`
+
+# Returns
+
+- `year_range::NamedTuple{(:first_year, :last_year), Tuple{Int64, Int64}}` - a NamedTuple where `first_year` is the first year data from the database was available and `last_year` where the last year data from the database was available
+"""
+function GetDatabaseYearRange(; tab=observation_period)
+    sql = From(tab) |> 
+    Group() |> 
+    Select(:first_year => Agg.min(Get.observation_period_end_date), 
+           :last_year => Agg.max(Get.observation_period_end_date)) |>
+           q -> render(q, dialect = OMOPCDMCohortCreator.dialect)
+
+    return sql
+
+end
+
+"""
+GetDatabasePersonIDs(; tab = person)
 
 Return SQL statement that gets all unique `person_id`'s from a database.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -46,7 +96,7 @@ function GetDatabasePersonIDs(; tab=person)
 end
 
 """
-GetPatientState(ids, conn; tab::SQLTable = location, join_tab::SQLTable = person)
+GetPatientState(ids, conn; tab = location, join_tab = person)
 
 Given a list of person IDs, find their home state.
 
@@ -57,8 +107,8 @@ Given a list of person IDs, find their home state.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Location table; default `location`
-- `join_tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Location table; default `location`
+- `join_tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -77,7 +127,7 @@ function GetPatientState(
 end
 
 """
-GetPatientState(ids; tab::SQLTable = location, join_tab::SQLTable = person)
+GetPatientState(ids; tab = location, join_tab = person)
 
 Return SQL statement where if given a list of person IDs, find their home state.
 
@@ -88,8 +138,8 @@ Return SQL statement where if given a list of person IDs, find their home state.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Location table; default `location`
-- `join_tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Location table; default `location`
+- `join_tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -113,7 +163,7 @@ function GetPatientState(
 end
 
 """
-GetPatientGender(ids, conn; tab::SQLTable = person)
+GetPatientGender(ids, conn; tab = person)
 
 Given a list of person IDs, find their gender.
 
@@ -124,7 +174,7 @@ Given a list of person IDs, find their gender.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -142,7 +192,7 @@ function GetPatientGender(
 end
 
 """
-GetPatientGender(ids, conn; tab::SQLTable = person)
+GetPatientGender(ids, conn; tab = person)
 
 TODO: Add docstring for this dispatch
 
@@ -153,7 +203,7 @@ TODO: Add docstring for this dispatch
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -174,7 +224,7 @@ function GetPatientGender(
 end
 
 """
-GetPatientEthnicity(ids, conn; tab::SQLTable = person)
+GetPatientEthnicity(ids, conn; tab = person)
 
 Given a list of person IDs, find their ethnicity.
 
@@ -185,7 +235,7 @@ Given a list of person IDs, find their ethnicity.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -203,7 +253,7 @@ function GetPatientEthnicity(
 end
 
 """
-GetPatientEthnicity(ids, conn; tab::SQLTable = person)
+GetPatientEthnicity(ids, conn; tab = person)
 
 TODO: Add dispatch docstring
 
@@ -214,7 +264,7 @@ TODO: Add dispatch docstring
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -233,7 +283,7 @@ function GetPatientEthnicity(ids; tab = person)
 end
 
 """
-GetPatientRace(ids, conn; tab::SQLTable = person)
+GetPatientRace(ids, conn; tab = person)
 
 Given a list of person IDs, find their race.
 
@@ -244,7 +294,7 @@ Given a list of person IDs, find their race.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -258,7 +308,7 @@ function GetPatientRace(ids, conn; tab=person)
 end
 
 """
-GetPatientRace(ids; tab::SQLTable = person)
+GetPatientRace(ids; tab = person)
 
 TODO: Add dispatch docstring
 
@@ -269,7 +319,7 @@ TODO: Add dispatch docstring
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -301,7 +351,7 @@ GetPatientAgeGroup(
         [70, 79],
         [80, 89],
     ],
-    tab::SQLTable = person,
+    tab = person,
 )
 
 Finds all individuals in age groups as specified by `age_groupings`.
@@ -319,10 +369,9 @@ Finds all individuals in age groups as specified by `age_groupings`.
 
 - `minuend` - the year that a patient's `year_of_birth` variable is subtracted from; default `:now`. There are three different options that can be set: 
     - `:now` - the year as of the day the code is executed given in UTC time
-    - `:db` - the last year that any record was found in the database using the "observation_period" table (considered by OHDSI experts to have the latest records in a database)
     - any year provided by a user as long as it is an `Integer` (such as 2022, 1998, etc.)
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -355,7 +404,7 @@ function GetPatientAgeGroup(
         [70, 79],
         [80, 89],
     ],
-    tab::SQLTable=person
+    tab=person
 ) 
 
 df = DBInterface.execute(conn, GetPatientAgeGroup(ids; minuend = minuend, age_groupings = age_groupings, tab = tab)) |> DataFrame
@@ -379,7 +428,7 @@ GetPatientAgeGroup(
         [70, 79],
         [80, 89],
     ],
-    tab::SQLTable = person,
+    tab = person,
 )
 
 TODO: Create dispatch docstring 
@@ -397,10 +446,9 @@ TODO: Create dispatch docstring
 
 - `minuend` - the year that a patient's `year_of_birth` variable is subtracted from; default `:now`. There are three different options that can be set: 
     - `:now` - the year as of the day the code is executed given in UTC time
-    - `:db` - the last year that any record was found in the database using the "observation_period" table (considered by OHDSI experts to have the latest records in a database)
     - any year provided by a user as long as it is an `Integer` (such as 2022, 1998, etc.)
 
-- `tab::SQLTable` - the `SQLTable` representing the Person table; default `person`
+- `tab` - the `SQLTable` representing the Person table; default `person`
 
 # Returns
 
@@ -432,14 +480,10 @@ function GetPatientAgeGroup(
         [70, 79],
         [80, 89],
     ],
-    tab::SQLTable=person
+    tab=person
 )
-    # TODO: _determine_calculated_year is not supported in GetPatientAgeGroup
-    # **Description:** This is because `conn` is not passed to this dispatch. Needs fix on the `refactor` branch.
-    # labels: bug 
-    # assignees: thecedarprince
 
-    # minuend = _determine_calculated_year(conn, minuend)
+    minuend = _determine_calculated_year(minuend)
     age_arr = []
 
     for grp in age_groupings
@@ -459,7 +503,7 @@ function GetPatientAgeGroup(
 end
 
 """
-GetPatientVisits(ids, conn; tab::SQLTable = visit_occurrence)
+GetPatientVisits(ids, conn; tab = visit_occurrence)
 
 Given a list of person IDs, find all their visits.
 
@@ -470,7 +514,7 @@ Given a list of person IDs, find all their visits.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
+- `tab` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
 
 # Returns
 
@@ -480,7 +524,7 @@ Given a list of person IDs, find all their visits.
 function GetPatientVisits(
     ids,
     conn;
-    tab::SQLTable=visit_occurrence
+    tab=visit_occurrence
 )
 
 df = DBInterface.execute(conn, GetPatientVisits(ids; tab = tab)) |> DataFrame
@@ -490,7 +534,7 @@ df = DBInterface.execute(conn, GetPatientVisits(ids; tab = tab)) |> DataFrame
 end
 
 """
-GetPatientVisits(ids, conn; tab::SQLTable = visit_occurrence)
+GetPatientVisits(ids, conn; tab = visit_occurrence)
 
 TODO: Add dispatch docstring
 
@@ -501,7 +545,7 @@ TODO: Add dispatch docstring
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
+- `tab` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
 
 # Returns
 
@@ -510,7 +554,7 @@ TODO: Add dispatch docstring
 """
 function GetPatientVisits(
     ids;
-    tab::SQLTable=visit_occurrence
+    tab=visit_occurrence
 )
 
     sql =
@@ -524,7 +568,7 @@ function GetPatientVisits(
 end
 
 """
-GetMostRecentConditions(ids, conn; tab::SQLTable = condition_occurrence)
+GetMostRecentConditions(ids, conn; tab = condition_occurrence)
 
 Given a list of person IDs, find their last recorded conditions.
 
@@ -535,7 +579,7 @@ Given a list of person IDs, find their last recorded conditions.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
+- `tab` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
 
 # Returns
 
@@ -544,7 +588,7 @@ Given a list of person IDs, find their last recorded conditions.
 function GetMostRecentConditions(
     ids,
     conn;
-    tab::SQLTable=condition_occurrence
+    tab=condition_occurrence
 )
 
 df = DBInterface.execute(conn, GetMostRecentConditions(ids; tab = tab)) |> DataFrame
@@ -554,7 +598,7 @@ df = DBInterface.execute(conn, GetMostRecentConditions(ids; tab = tab)) |> DataF
 end
 
 """
-GetMostRecentConditions(ids, conn; tab::SQLTable = condition_occurrence)
+GetMostRecentConditions(ids, conn; tab = condition_occurrence)
 
 TODO: Create dispatch docstring
 
@@ -565,7 +609,7 @@ TODO: Create dispatch docstring
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
+- `tab` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
 
 # Returns
 
@@ -573,7 +617,7 @@ TODO: Create dispatch docstring
 """
 function GetMostRecentConditions(
     ids;
-    tab::SQLTable=condition_occurrence
+    tab=condition_occurrence
 )
 
     sql =
@@ -597,7 +641,7 @@ function GetMostRecentConditions(
 end
 
 """
-GetMostRecentVisit(ids, conn; tab::SQLTable = visit_occurrence)
+GetMostRecentVisit(ids, conn; tab = visit_occurrence)
 
 Given a list of person IDs, find their last recorded visit.
 
@@ -608,7 +652,7 @@ Given a list of person IDs, find their last recorded visit.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
+- `tab` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
 
 # Returns
 
@@ -617,7 +661,7 @@ Given a list of person IDs, find their last recorded visit.
 function GetMostRecentVisit(
     ids,
     conn;
-    tab::SQLTable=visit_occurrence
+    tab=visit_occurrence
 )
 
 df = DBInterface.execute(conn, GetMostRecentVisit(ids; tab = tab)) |> DataFrame
@@ -626,7 +670,7 @@ df = DBInterface.execute(conn, GetMostRecentVisit(ids; tab = tab)) |> DataFrame
 end
 
 """
-GetMostRecentVisit(ids, conn; tab::SQLTable = visit_occurrence)
+GetMostRecentVisit(ids, conn; tab = visit_occurrence)
 
 TODO: Create dispatch docstring
 
@@ -637,7 +681,7 @@ TODO: Create dispatch docstring
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
+- `tab` - the `SQLTable` representing the Visit Occurrence table; default `visit_occurrence`
 
 # Returns
 
@@ -645,7 +689,7 @@ TODO: Create dispatch docstring
 """
 function GetMostRecentVisit(
     ids;
-    tab::SQLTable=visit_occurrence
+    tab=visit_occurrence
 )
 
     sql =
@@ -669,7 +713,7 @@ function GetMostRecentVisit(
 end
 
 """
-GetVisitCondition(visit_ids, conn; tab::SQLTable = visit_occurrence)
+GetVisitCondition(visit_ids, conn; tab = visit_occurrence)
 
 Given a list of visit IDs, find their corresponding conditions.
 
@@ -680,7 +724,7 @@ Given a list of visit IDs, find their corresponding conditions.
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
+- `tab` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
 
 # Returns
 
@@ -689,7 +733,7 @@ Given a list of visit IDs, find their corresponding conditions.
 function GetVisitCondition(
     visit_ids,
     conn;
-    tab::SQLTable=condition_occurrence
+    tab=condition_occurrence
 )
 
 df = DBInterface.execute(conn, GetVisitCondition(visit_ids; tab = tab)) |> DataFrame
@@ -699,7 +743,7 @@ df = DBInterface.execute(conn, GetVisitCondition(visit_ids; tab = tab)) |> DataF
 end
 
 """
-GetVisitCondition(visit_ids, conn; tab::SQLTable = visit_occurrence)
+GetVisitCondition(visit_ids, conn; tab = visit_occurrence)
 
 TODO: Add dispatch docstring
 
@@ -710,7 +754,7 @@ TODO: Add dispatch docstring
 
 # Keyword Arguments:
 
-- `tab::SQLTable` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
+- `tab` - the `SQLTable` representing the Condition Occurrence table; default `condition_occurrence`
 
 # Returns
 
@@ -718,7 +762,7 @@ TODO: Add dispatch docstring
 """
 function GetVisitCondition(
     visit_ids;
-    tab::SQLTable=condition_occurrence
+    tab=condition_occurrence
 )
 
     sql =
@@ -731,4 +775,4 @@ function GetVisitCondition(
 
 end
 
-export GetDatabasePersonIDs, GetPatientState, GetPatientGender, GetPatientRace, GetPatientAgeGroup, GetPatientVisits, GetMostRecentConditions, GetMostRecentVisit, GetVisitCondition, GetPatientEthnicity
+export GetDatabasePersonIDs, GetPatientState, GetPatientGender, GetPatientRace, GetPatientAgeGroup, GetPatientVisits, GetMostRecentConditions, GetMostRecentVisit, GetVisitCondition, GetPatientEthnicity, GetDatabaseYearRange

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -3,24 +3,17 @@ Internal function to determine the latest year for time-based calculations
 
 # Arguments: 
 
-`conn` - database connection using DBInterface
-
 `calculated_year` - three different options can be used: 
     - `:now` - the year as of the day the code is executed given in UTC time
-    - `:db` - the last year that any record was found in the database using the "observation_period" table (considered by OHDSI experts to have the latest records in a database)
     - any year provided by a user as long as it is an `Integer` (such as 2022, 1998, etc.)
 
 # Returns
 
 - `calculated_year` - the year that was determined to be used for further calculations
 """
-function _determine_calculated_year(conn, calculated_year)
+function _determine_calculated_year(calculated_year)
     if calculated_year == :now
         calculated_year = year(now(tz"UTC"))
-    elseif calculated_year == :db
-        #OPTIM: Get the max observation_period_end_date down to only one values
-        #OPTIM: Figure out how to do this with FunSQL or default to a SQL string
-        calculated_year = From(observation_period) |> Select(Get.observation_period_end_date) |> q -> render(q, dialect = dialect) |> x -> DBInterface.execute(conn, String(x)) |> DataFrame |> df -> maximum(df.observation_period_end_date) |> unix2datetime |> Dates.year
     end
 
     return calculated_year

--- a/test/sqlite/filters.jl
+++ b/test/sqlite/filters.jl
@@ -3,20 +3,21 @@
     VisitFilterPersonIDs([9201.0], sqlite_conn)
     test_person_ids = [1, 2, 3, 5, 32, 35, 36, 42, 61, 80]
 
-    res =  sort(VisitFilterPersonIDs([9201.0], sqlite_conn))
-    @test test_person_ids == res[1:10]
+    res = sort(VisitFilterPersonIDs([9201.0], sqlite_conn))
+    @test test_person_ids == res.person_id[1:10]
 end
 
 @testset "ConditionFilterPersonIDs Tests" begin
     #test for 192671.0 - singe condition code
     test_person_ids_single = [3, 32, 35, 61, 80, 99, 115, 116, 133, 135]
     res =  sort(ConditionFilterPersonIDs([192671.0], sqlite_conn))
-    @test test_person_ids_single == res[1:10]
+    @test test_person_ids_single == res.person_id[1:10]
 
     #test for multiple condition codes - 28060 and 192671
     test_person_ids_multiple = [1, 3, 5, 9, 11, 12, 17, 18, 19, 32]
-    res_multiple = sort(ConditionFilterPersonIDs([192671.0, 28060.], sqlite_conn))[1:10]
-    @test test_person_ids_multiple == res_multiple[1:10]
+    res_multiple = sort(ConditionFilterPersonIDs([192671.0, 28060.], sqlite_conn))
+
+    @test test_person_ids_multiple == res_multiple.person_id[1:10]
 	
 end
 
@@ -34,7 +35,7 @@ end
     148.0,
     164.0,
     190.0]
-    res_single = sort(RaceFilterPersonIDs(race_id_single, sqlite_conn))[1:10]
+    res_single = sort(RaceFilterPersonIDs(race_id_single, sqlite_conn)).person_id[1:10]
     @test person_list_8516 == res_single
 
     #test for multiple IDs
@@ -50,7 +51,7 @@ end
     12.0,
     16.0,
     17.0]
-    res_multiple = sort(RaceFilterPersonIDs(race_ids_multiple, sqlite_conn))[1:10]
+    res_multiple = sort(RaceFilterPersonIDs(race_ids_multiple, sqlite_conn)).person_id[1:10]
     @test person_list_multiple == res_multiple
 end
 
@@ -68,7 +69,7 @@ end
    18.0,
    19.0,
    30.0]
-   res_single = sort(GenderFilterPersonIDs(gender_single, sqlite_conn))[1:10]
+   res_single = sort(GenderFilterPersonIDs(gender_single, sqlite_conn)).person_id[1:10]
    @test person_list_genders == res_single
 
    gender_id_multiple = [8532, 8507.0]
@@ -83,7 +84,7 @@ end
    11.0,
    12.0,
    16.0]
-   res_multiple = sort(GenderFilterPersonIDs(gender_id_multiple, sqlite_conn))[1:10]
+   res_multiple = sort(GenderFilterPersonIDs(gender_id_multiple, sqlite_conn)).person_id[1:10]
    @test person_list_multiple == res_multiple
 end
 

--- a/test/sqlite/getters.jl
+++ b/test/sqlite/getters.jl
@@ -36,8 +36,7 @@ end
 	test_age_grouping_2 = [[45, 49], [50, 54], [55, 59], [60, 64], [65, 69], [70, 74], [75, 79]]
 
 	default_minuend = :now
-	minuend_1 = :db
-	minuend_2 = 2022
+	minuend_now = 2022
 	
 	default_age_grouping_values = ["0 - 9", "10 - 19", "20 - 29", "30 - 39", "40 - 49", "50 - 59", "60 - 69", "70 - 79", "80 - 89"]
 
@@ -61,13 +60,10 @@ end
 	default_test = default_test[!, [:person_id, :age_group]]
 	default_test.age_group = convert(Vector{Union{Missing, String}}, default_test.age_group)
 	
-	minuend_1_test = DataFrame(:person_id => [6.0, 123.0, 129.0, 16.0, 65.0, 74.0, 42.0, 187.0, 18.0, 111.0], :age_group => ["40 - 59", missing, "40 - 59", "40 - 59", "40 - 59", "40 - 59", missing, missing, "40 - 59", "40 - 59"])
-
-	minuend_2_test = DataFrame(:person_id => [6.0, 123.0, 129.0, 16.0, 65.0, 74.0, 42.0, 187.0, 18.0, 111.0], :age_group => ["55 - 59", "70 - 74", "45 - 49", "50 - 54", "55 - 59", "50 - 54", missing, "75 - 79", "55 - 59", "45 - 49"])
+	minuend_now_test = DataFrame(:person_id => [6.0, 123.0, 129.0, 16.0, 65.0, 74.0, 42.0, 187.0, 18.0, 111.0], :age_group => ["55 - 59", "70 - 74", "45 - 49", "50 - 54", "55 - 59", "50 - 54", missing, "75 - 79", "55 - 59", "45 - 49"])
 
 	@test isequal(default_test, GetPatientAgeGroup(test_ids, sqlite_conn; minuend = default_minuend, age_groupings = default_age_grouping))
-	@test isequal(minuend_1_test, GetPatientAgeGroup(test_ids, sqlite_conn; minuend = minuend_1, age_groupings = test_age_grouping_1))
-	@test isequal(minuend_2_test, GetPatientAgeGroup(test_ids, sqlite_conn; minuend = minuend_2, age_groupings = test_age_grouping_2))
+	@test isequal(minuend_now_test, GetPatientAgeGroup(test_ids, sqlite_conn; minuend = minuend_now, age_groupings = test_age_grouping_2))
 end
 
 #Tests for GetPatientVisits


### PR DESCRIPTION
Closes #25 as this removes the `:db` option from `GetPatientAgeGroup` due to too many mix-ups with the calculation logic. Instead, it is up to the user to use `GetDatabaseYearRange` which operates over a database connection to find years that a database provides data for. Then, they can use a year of their choice as their minuend in `GetPatientAgeGroup`.